### PR TITLE
Lock base version to Python 3.6 until scrapy works on Python 3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3
+# TODO(pascal): Switch back to python:3 when scrapy is compatible with Python 3.7
+# https://github.com/twisted/twisted/pull/966 needs to be released.
+FROM python:3.6
 
 # TODO: Investigate why this and the following requirements are needed (copied
 # over from tailordev/pandas).


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/docker-pandas/6)
<!-- Reviewable:end -->
