### PR TITLE
Revert "Bump pandas from 1.1.4 to 1.1.5"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 airtable==0.3.1
 csvkit==1.0.5
 numpy==1.19.4
-pandas==1.1.5
+pandas==1.1.4
 sas7bdat==2.2.3
 scipy==1.5.4
 sklearn==0.0


### PR DESCRIPTION
This reverts commit 45bbe72f4e44b70cf930a490bf26d9bf98aefdea.

Pandas 1.1.5 does not support XLSX anymore, we need to fix this before
upgrading.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/docker-pandas/43)
<!-- Reviewable:end -->
